### PR TITLE
mdh-client-feedback-change-1

### DIFF
--- a/docs/learn/master-data-hub/index.md
+++ b/docs/learn/master-data-hub/index.md
@@ -60,9 +60,12 @@ Once the extension is activated for a queue, it will be automatically triggered 
 
 ![Master Data Hub: select queue](./img/mdh-select-queue.png)
 
-### Step 4: Assign the token owner
+### Step 4: Assign the token owner (optional)
 
-Token owner must have an "Admin" role assigned in Rossum. User queries the database and adds the results to annotation data.
+For our clients, this step is not necessary. An account with admin rights will be able to create the extension, and the owner of the extension will automatically be assigned to the account that created it. Therefore, this step is not displayed in the User Interface.   
+⚠️ However, if you plan to use a different account later, please ensure that you create the extension with that account, or contact our Support team to reassign ownership, for example, to a special technical user.
+
+For Rossum Employees: Token owner must have an "Admin" role assigned in Rossum. User queries the database and adds the results to annotation data.
 
 ![Master Data Hub: token owner](./img/mdh-token-owner.png)
 


### PR DESCRIPTION
It was noted that there is an instruction to add owner for the extension. However, our clients can't see this option in UI as it is automated for them. The creator is automatically assigned. Therefore there is a need to explicitly explain when it should be requested to be changed and mark this step as needed only for Rossum Employees that are doing implementation for a client. 